### PR TITLE
Added OpenAPI Info Page

### DIFF
--- a/InstaTonne/urls.py
+++ b/InstaTonne/urls.py
@@ -17,6 +17,7 @@ from django.contrib import admin
 from django.urls import path, include
 from django.contrib.auth.models import User
 from rest_framework import routers, serializers, viewsets
+from rest_framework.schemas import get_schema_view
 
 # Serializers define the API representation.
 class UserSerializer(serializers.HyperlinkedModelSerializer):
@@ -36,5 +37,25 @@ router.register(r'users', UserViewSet)
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include(router.urls)),
-    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')) 
+    path('api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    path('openapi', get_schema_view(
+        title="InstaTonne API",
+        description="This will show schema info for everything in urlpatterns (in urls.py)",
+        version="1.0.0" # We will probably not update this unless we make API changes later
+        # url='https://www.example.org/api/' <- if we want a custom url for a schema, add it here
+        # urlconf=ROOT_URLCONF <- ROOT_URLCONF is default, so we probably won't need to add this
+    ), name='openapi-schema'), 
 ]
+
+# schema_generator.get_schema() can be used to get a JSON object containing the same data, in case we need to export it:
+# (This JSON is identical to the one generated above with get_schema_view)
+# Note: this grabs data from urlpatterns using Django magic, so needs to be after it in this file
+
+# from rest_framework.schemas.openapi import SchemaGenerator
+# schema_generator = SchemaGenerator(title='InstaTonne API',
+#         description="This will print schema info for everything in urlpatterns (in urls.py)",
+#         version="1.0.0" # We will probably not update this unless we make API changes later
+#         # url='https://www.example.org/api/' <- if we want a custom url for a schema, add it here
+#         # urlconf=ROOT_URLCONF <- ROOT_URLCONF is default, so we probably won't need to add this
+#     )
+# print(schema_generator.get_schema())

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.6.0
 Django==4.1.6
 sqlparse==0.4.3
 djangorestframework==3.14.0
+uritemplate==4.1.1


### PR DESCRIPTION
Closes #43. 

Added a page showing our OpenAPI spec. Also added commented code if we ever need the raw JSON.

run project with "python3 manage.py runserver"

OpenAPI view can be found at http://127.0.0.1:8000/openapi