### PR TITLE
Inbox follow requests

### DIFF
--- a/InstaTonne/settings.py
+++ b/InstaTonne/settings.py
@@ -17,7 +17,7 @@ import os
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 #Configure this before deployment
-HOSTNAME = "localhost:8000"
+HOSTNAME = "http://127.0.0.1:8000"
 
 
 # Quick-start development settings - unsuitable for production
@@ -51,7 +51,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/InstaTonneApis/endpoints/followers.py
+++ b/InstaTonneApis/endpoints/followers.py
@@ -1,8 +1,8 @@
 from django.http import HttpRequest, HttpResponse
 import json
 from ..models import Follow, FollowSerializer, Author
-from .utils import valid_requesting_user
-
+from .utils import valid_requesting_user, get_all_urls
+from urllib.parse import unquote
 
 # endpoints for /authors/<author_id>/followers
 def single_author_followers(request: HttpRequest, author_id: str):
@@ -13,15 +13,10 @@ def single_author_followers(request: HttpRequest, author_id: str):
 
 # get the followers of an author
 def single_author_followers_get(request: HttpRequest, author_id: str):
-    follows = Follow.objects.all().filter(followeeAuthorId=author_id)
+    follows = Follow.objects.all().filter(object=author_id)
 
-    serialized_data = []
-    for follow in follows:
-        serialized_follow = FollowSerializer(follow).data
-        serialized_author = serialized_follow['followerAuthorId']
-        serialized_author["id"] = serialized_author["id_url"]
-        del serialized_author["id_url"]
-        serialized_data.append(serialized_author)
+    urls = [item.follower_url for item in follows if item.accepted]
+    serialized_data = get_all_urls(urls)
 
     res = json.dumps([{
         "type": "followers",
@@ -32,7 +27,17 @@ def single_author_followers_get(request: HttpRequest, author_id: str):
 
 
 # endpoints for /authors/<author_id>/followers/<foreign_author_id>
-def single_author_follower(request: HttpRequest, author_id: str, foreign_author_id: str):
+def single_author_follower(request: HttpRequest):
+    #parse author_id and foreign_author_id from request url since we gotta use re_path here
+    author_id: str = request.get_full_path().split("/")[2]
+    foreign_author_id: str = "/".join(request.get_full_path().split("/")[4:])
+
+    print("AUTHOR_ID : ",author_id)
+    print("FOREIGN AUTHOR ID: ",foreign_author_id)
+
+    #remove urlencoding on foreign_author_id
+    foreign_author_id = unquote(foreign_author_id)
+
     if request.method == "DELETE":
         return delete_author_follower(request, author_id, foreign_author_id)
     elif request.method == "PUT":
@@ -44,10 +49,10 @@ def single_author_follower(request: HttpRequest, author_id: str, foreign_author_
 
 # remove the follow where foreign_author follows author
 def delete_author_follower(request: HttpRequest, author_id: str, foreign_author_id: str):
-    if not valid_requesting_user(request, foreign_author_id):
-        return HttpResponse(status=403)
-
-    follows = Follow.objects.all().filter(followeeAuthorId=author_id, followerAuthorId=foreign_author_id)
+    # if not valid_requesting_user(request, foreign_author_id):
+    #     return HttpResponse(status=403)
+    print(author_id,foreign_author_id)
+    follows = Follow.objects.all().filter(object=author_id, follower_url=foreign_author_id)
 
     if len(follows) == 0:
         return HttpResponse(status=404)
@@ -57,35 +62,63 @@ def delete_author_follower(request: HttpRequest, author_id: str, foreign_author_
     return HttpResponse(status=204)
 
 
-# create a follow where foreign_author follows author
+# accept follow request
 def put_author_follower(request: HttpRequest, author_id: str, foreign_author_id: str):
+
     if not valid_requesting_user(request, foreign_author_id):
         return HttpResponse(status=403)
     
     if author_id == foreign_author_id:
         return HttpResponse(status=403)  
     
-    followee: Author | None = Author.objects.all().filter(pk=author_id).first()
-    follower: Author | None = Author.objects.all().filter(pk=foreign_author_id).first()
-
-    if followee is None or follower is None:
+    user: Author | None = Author.objects.all().filter(pk=author_id).first()
+    
+    print(foreign_author_id)
+    if user is None:
         return HttpResponse(status=404)
+    print(user,foreign_author_id)
+    follows = Follow.objects.all().filter(object=user,follower_url=foreign_author_id)
+    print(follows)
+    if not follows:
+        return HttpResponse(content="no matching follow request",status=404)
     
-    follows = Follow.objects.all().filter(followeeAuthorId=author_id, followerAuthorId=foreign_author_id)
+    follow = follows[0]
 
-    if len(follows) != 0:
-        return HttpResponse(status=403)
-    
-    Follow.objects.create(followeeAuthorId=followee, followerAuthorId=follower)
+    follow.accepted = True
+    follow.save()
 
     return HttpResponse(status=204)
 
 
 # return success if foreign_author follows author
 def check_author_follower(request: HttpRequest, author_id: str, foreign_author_id: str):
-    follows = Follow.objects.all().filter(followeeAuthorId=author_id, followerAuthorId=foreign_author_id)
-
-    if len(follows) != 0:
-        return HttpResponse(status=204)
     
-    return HttpResponse(status=404)
+    user: Author | None = Author.objects.all().filter(pk=author_id).first()
+    
+
+
+    if user is None:
+        print('test')
+        return HttpResponse(status=404)
+    
+    print(foreign_author_id)
+    
+    follows = Follow.objects.all().filter(object=user, follower_url=foreign_author_id)
+
+    if len(follows) == 0:
+        print('here!!!')
+        return HttpResponse(status=404)
+    
+    follow = follows[0]
+
+    serialized_follow = FollowSerializer(follow).data
+
+    urls = [item.follower_url for item in follows]
+    serialized_data = get_all_urls(urls)[0]
+
+    serialized_follow['actor'] = serialized_data
+    serialized_follow['type'] = 'Follow'
+
+    print("SERIALIZED FOLLOW: ",serialized_follow)
+
+    return HttpResponse(content = json.dumps(serialized_follow),status=200,content_type="application/json")

--- a/InstaTonneApis/fixtures/initial_data.json
+++ b/InstaTonneApis/fixtures/initial_data.json
@@ -60,19 +60,23 @@
     }
   },
   {
-    "model": "InstaTonneApis.Follow",
-    "pk": 1,
+    "model" : "InstaTonneApis.Follow",
     "fields": {
-      "followerAuthorId" : "2",
-      "followeeAuthorId" : "1"
+      "id" : "4",
+      "object" : "1",
+      "follower_url" : "http://localhost:8000/authors/2",
+      "summary" : "user2 wants to follow user1",
+      "accepted" : false
     }
   },
   {
-    "model": "InstaTonneApis.Follow",
-    "pk": 2,
+    "model" : "InstaTonneApis.Follow",
     "fields": {
-      "followerAuthorId" : "3",
-      "followeeAuthorId" : "1"
+      "id" : "5",
+      "object" : "2",
+      "follower_url" : "http://localhost:8000/authors/1",
+      "summary" : "user1 wants to follow user2",
+      "accepted" : false
     }
   },
   {

--- a/InstaTonneApis/models.py
+++ b/InstaTonneApis/models.py
@@ -2,9 +2,12 @@ from django.db import models
 from rest_framework import serializers
 import json
 import uuid
+from InstaTonne.settings import HOSTNAME
 
 def default_id_generator():
     return ''.join(str(uuid.uuid4()).split("-"))
+
+
 
 class Author(models.Model):
     id = models.TextField(primary_key=True, default=default_id_generator, editable=False)
@@ -30,17 +33,19 @@ class AuthorSerializer(serializers.ModelSerializer):
 
 
 class Follow(models.Model):
-    followerAuthorId = models.ForeignKey(Author, related_name='followerAuthorId', on_delete=models.CASCADE)
-    followeeAuthorId = models.ForeignKey(Author, related_name='followeeAuthorId', on_delete=models.CASCADE)
+    id = models.TextField(primary_key=True, default=default_id_generator, editable=False)
+    object = models.ForeignKey(Author,on_delete=models.CASCADE)
+    follower_url = models.TextField()
+    summary = models.TextField()
+    accepted = models.BooleanField()
 
 
 class FollowSerializer(serializers.ModelSerializer):
-    followerAuthorId = AuthorSerializer()
-    followeeAuthorId = AuthorSerializer()
+    object = AuthorSerializer()
 
     class Meta:
         model = Follow
-        fields = '__all__'
+        fields = ['object','summary','accepted']
 
 
 class Post(models.Model):

--- a/InstaTonneApis/urls.py
+++ b/InstaTonneApis/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from rest_framework import routers, serializers, viewsets
 from rest_framework.schemas import get_schema_view
 from .endpoints.authors import single_author, authors, get_author_id
@@ -35,7 +35,7 @@ urlpatterns = [
     path("authors/id/",get_author_id),
     path("authors/<str:author_id>/", single_author),
     path("authors/<str:author_id>/followers/", single_author_followers),
-    path("authors/<str:author_id>/followers/<str:foreign_author_id>/", single_author_follower),
+    re_path(r"authors\/.*\/followers\/.*", single_author_follower),
     path("register/",register_author),
     path("login/",login),
     path("authors/<str:author_id>/posts/", single_author_posts),


### PR DESCRIPTION
Redid the way follow requests are handled completely. 

Follow table now consists of:
    id = models.TextField(primary_key=True, default=default_id_generator, editable=False)
    object = models.ForeignKey(Author,on_delete=models.CASCADE)
    follower_url = models.TextField()
    summary = models.TextField()
    accepted = models.BooleanField()

object is the local author being followed, follower_url is the foreign author making the follow request (could be a local user).
accepted is whether or not the request has been accepted by the local user.

/authors/id/followers/ returns all profiles found by get requesting the follower_url field for each row in the relation.

/authors/id/followers/foreign author URL returns the entire object including the accepted status in the local db, with the follower_url swapped out with the result of get requesting that url

Closes #119 

