### PR TITLE
Post editor functionality

### DIFF
--- a/InstaTonne-FrontEnd/src/components/ErrorPage.vue
+++ b/InstaTonne-FrontEnd/src/components/ErrorPage.vue
@@ -1,0 +1,22 @@
+<template>
+  <div
+    class="viewBox"
+  >
+    {{ props.errorMessage }}
+  </div>
+</template>
+
+<script setup lang="ts">
+
+const props = defineProps({
+errorMessage: {
+    type: String,
+    default: "404 Page Not Found"
+}
+})
+
+</script>
+
+<style scoped>
+</style>
+    

--- a/InstaTonne-FrontEnd/src/components/PostEditor.vue
+++ b/InstaTonne-FrontEnd/src/components/PostEditor.vue
@@ -9,6 +9,9 @@
       size="200"
       style="margin: 10em;"
     />
+    <div v-else-if="errorMessage.length > 0">
+      <ErrorPage :error-message="errorMessage" />
+    </div>
     <div v-else>
       <div style="display: flex;">
         <AuthorCard :author-info="postData.author" />
@@ -50,6 +53,25 @@
         v-model="postData.content"
         clearable
       />
+      <v-combobox
+        v-model="postData.categories"
+        chips
+        clearable
+        label="Categories"
+        multiple
+      >
+        <template #selection="{ attrs, item, select, selected }">
+          <v-chip
+            v-bind="attrs"
+            :model-value="selected"
+            closable
+            @click="select"
+            @click:close="remove(item)"
+          >
+            {{ item }}
+          </v-chip>
+        </template>
+      </v-combobox>
       <v-btn
         @click="savePost"
       >
@@ -61,23 +83,38 @@
   
 <script setup lang="ts">
 import { ref, onBeforeMount } from 'vue'
+import { useRoute } from "vue-router";
 import AuthorCard from './AuthorCard.vue'
-import { createHTTP } from '../axiosCalls'
+import ErrorPage from './ErrorPage.vue'
+import { createHTTP, USER_AUTHOR_ID_COOKIE } from '../axiosCalls'
+import Cookies from "js-cookie";
 
 const loading = ref(true)
+const errorMessage = ref("")
 const postData = ref({});
+
+let route = useRoute();
+
 onBeforeMount(async () => {
-  await createHTTP('authors/1/posts/1/').get().then((response: { data: object }) => {
-    postData.value = response.data;
+  if (Cookies.get(USER_AUTHOR_ID_COOKIE) != route.params.id) {
+    errorMessage.value = "403 Forbidden";
     loading.value = false;
-  });
+  } else {
+    await createHTTP(`authors/${route.params.id}/posts/${route.params.postid}/`).get().then((response: { data: object }) => {
+      postData.value = response.data;
+      loading.value = false;
+    }).catch(() => {
+      errorMessage.value = "404 Post Not Found"
+      loading.value = false;
+    });
+  }
 })
 
 async function savePost() {
   // eventually this should do a backend call to push postData
   // Note: since everything is binded, all the changes should be stored in postData already!
   loading.value = true;
-  await createHTTP('authors/1/posts/1/').post(JSON.stringify(postData.value)).then((response: { data: object }) => {
+  await createHTTP(`authors/${route.params.id}/posts/${route.params.postid}/`).post(JSON.stringify(postData.value)).then((response: { data: object }) => {
     loading.value = false;
   });
 }

--- a/InstaTonne-FrontEnd/src/components/PostEditor.vue
+++ b/InstaTonne-FrontEnd/src/components/PostEditor.vue
@@ -95,26 +95,23 @@ const postData = ref({});
 
 let route = useRoute();
 
+const authorId = Cookies.get(USER_AUTHOR_ID_COOKIE);
+
 onBeforeMount(async () => {
-  if (Cookies.get(USER_AUTHOR_ID_COOKIE) != route.params.id) {
-    errorMessage.value = "403 Forbidden";
+  await createHTTP(`authors/${authorId}/posts/${route.params.postid}/`).get().then((response: { data: object }) => {
+    postData.value = response.data;
     loading.value = false;
-  } else {
-    await createHTTP(`authors/${route.params.id}/posts/${route.params.postid}/`).get().then((response: { data: object }) => {
-      postData.value = response.data;
-      loading.value = false;
-    }).catch(() => {
-      errorMessage.value = "404 Post Not Found"
-      loading.value = false;
-    });
-  }
+  }).catch(() => {
+    errorMessage.value = "404 Post Not Found"
+    loading.value = false;
+  });
 })
 
 async function savePost() {
   // eventually this should do a backend call to push postData
   // Note: since everything is binded, all the changes should be stored in postData already!
   loading.value = true;
-  await createHTTP(`authors/${route.params.id}/posts/${route.params.postid}/`).post(JSON.stringify(postData.value)).then((response: { data: object }) => {
+  await createHTTP(`authors/${authorId}/posts/${route.params.postid}/`).post(JSON.stringify(postData.value)).then((response: { data: object }) => {
     loading.value = false;
   });
 }

--- a/InstaTonne-FrontEnd/src/components/UserPost.vue
+++ b/InstaTonne-FrontEnd/src/components/UserPost.vue
@@ -1,22 +1,19 @@
 <template>
-    <div class="viewBox">
-
-      <br />
-      <div>
-
-          <PostFullCard
-            v-bind:postData="post"
-            v-if="(post.type = 'post')"
-          ></PostFullCard>
-
-      </div>
-      <div id="app"></div>
+  <div class="viewBox">
+    <br>
+    <div>
+      <PostFullCard
+        v-if="(post.type = 'post')"
+        :post-data="post"
+      />
     </div>
-  </template>
+    <div id="app" />
+  </div>
+</template>
   
   <script setup lang="ts">
   import { ref } from "vue";
-  import {useRoute} from "vue-router";
+  import { useRoute } from "vue-router";
   import PostFullCard from "./stream_cards/PostFullCard.vue";
   import Cookies from "js-cookie";
   // defineProps<{ msg: string }>()

--- a/InstaTonne-FrontEnd/src/main.ts
+++ b/InstaTonne-FrontEnd/src/main.ts
@@ -38,7 +38,7 @@ import UserPost from "./components/UserPost.vue";
 const routes = [
   { path: "/", name: "Home", component: HomePage },
   { path: "/about", name: "About", component: AboutPage },
-  { path: "/PostEditor", name: "PostEditor", component: PostEditor },
+  { path: "/authors/:id/posteditor/:postid/", name: "PostEditor", component: PostEditor },
   {
     path: "/FollowRequests",
     name: "FollowRequests",
@@ -52,7 +52,6 @@ const routes = [
 export const nav_bar_routes = [
   { path: "/", name: "Home", component: HomePage },
   { path: "/about", name: "About", component: AboutPage },
-  { path: "/PostEditor", name: "PostEditor", component: PostEditor },
   {
     path: "/FollowRequests",
     name: "FollowRequests",

--- a/InstaTonne-FrontEnd/src/main.ts
+++ b/InstaTonne-FrontEnd/src/main.ts
@@ -38,7 +38,7 @@ import UserPost from "./components/UserPost.vue";
 const routes = [
   { path: "/", name: "Home", component: HomePage },
   { path: "/about", name: "About", component: AboutPage },
-  { path: "/authors/:id/posteditor/:postid/", name: "PostEditor", component: PostEditor },
+  { path: "/posteditor/:postid/", name: "PostEditor", component: PostEditor },
   {
     path: "/FollowRequests",
     name: "FollowRequests",

--- a/InstaTonneApis/endpoints/utils.py
+++ b/InstaTonneApis/endpoints/utils.py
@@ -4,7 +4,7 @@ from threading import Thread, Lock
 import json
 import requests
 
-def get_all_urls(urls : list[str]):
+def get_all_urls(urls):
     inbox_lock = Lock()
     threads : list[Thread] = []
     result = []

--- a/InstaTonneApis/fixtures/initial_data.json
+++ b/InstaTonneApis/fixtures/initial_data.json
@@ -22,7 +22,7 @@
     "model": "InstaTonneApis.Author",
     "fields": {
       "id" : "1",
-      "userID" : "2",
+      "userID" : "1",
       "type" : "author",
       "id_url" : "id_url1",
       "url" : "url1",
@@ -37,6 +37,7 @@
       "model": "InstaTonneApis.Author",
       "fields": {
         "id" : "2",
+	"userID" : "2",
         "type" : "author",
         "id_url" : "id_url2",
         "url" : "url2",
@@ -50,6 +51,7 @@
     "model": "InstaTonneApis.Author",
     "fields": {
       "id" : "3",
+      "userID" : "3",
       "type" : "author",
       "id_url" : "id_url3",
       "url" : "url3",


### PR DESCRIPTION
closes #66 

User can only edit their own posts, so the path has no authorId.

The page is unstyled for now, but all the functionality is there.

If you go to a post Id that does not exist, the page will give a 404 error.

example URL: http://localhost:5173/posteditor/1/