### PR TITLE
Follow button

### DIFF
--- a/InstaTonne-FrontEnd/src/components/ProfilePage.vue
+++ b/InstaTonne-FrontEnd/src/components/ProfilePage.vue
@@ -10,6 +10,11 @@
     <br>
     <a v-bind:href="profileData.github"><p>Github: {{profileData.github}}</p></a>
     <a v-bind:href="profileData.host"><p>Origin: {{profileData.host}}</p></a>
+    <v-btn
+    class="button"
+
+    @click="follow()"
+  >
     <br>
     <div class="flex-container">
       <img class="profile-picture" v-bind:src="profileData.profileImage">
@@ -84,6 +89,12 @@
     posts.value = data.items;
     console.log(response.data, 567);
   });
+
+
+  function follow(){
+
+    createHTTP(`authors/${profileId}/followers`)
+  }
 
   
 

--- a/InstaTonne-FrontEnd/src/components/ProfilePage.vue
+++ b/InstaTonne-FrontEnd/src/components/ProfilePage.vue
@@ -10,11 +10,6 @@
     <br>
     <a v-bind:href="profileData.github"><p>Github: {{profileData.github}}</p></a>
     <a v-bind:href="profileData.host"><p>Origin: {{profileData.host}}</p></a>
-    <v-btn
-    class="button"
-
-    @click="follow()"
-  >
     <br>
     <div class="flex-container">
       <img class="profile-picture" v-bind:src="profileData.profileImage">
@@ -74,7 +69,8 @@
   createHTTP(`authors/${profileId}/followers/`)
   .get()
   .then((response) => {
-    let data = response.data[0]
+    console.log(response,123123123);
+    let data = response.data
     console.log(data, 51515);
     followers.value = data.items;
     follow_count.value = data.items.length;

--- a/InstaTonne-FrontEnd/src/components/ProfilePage.vue
+++ b/InstaTonne-FrontEnd/src/components/ProfilePage.vue
@@ -19,8 +19,10 @@
         <span class="followers"><br><br>Followers: {{ follow_count }}</span>
       </a>
     </div>
+    <v-btn @click="follow()" :disabled="!canFollow">
+      Follow
+    </v-btn>
     <br>
-
     <br>
     <div class="flex-container">
       <div
@@ -35,15 +37,29 @@
       </div>
       </a>
       </div>
+      <v-snackbar v-model="showStatus">
+        {{ statusMessage }}
+
+        <template #actions>
+          <v-btn
+            color="blue"
+            variant="text"
+            @click="statusMessage = ''"
+          >
+            Close
+          </v-btn>
+        </template>
+      </v-snackbar>
     </div>
   </div>
 </template>
   
   <script setup lang="ts">
-  import { ref } from 'vue'
+  import { ref, onMounted, computed } from 'vue'
   import { USER_AUTHOR_ID_COOKIE, createHTTP } from '../axiosCalls';
   import {useRoute} from "vue-router";
   import Cookies from "js-cookie";
+
 
   const route = useRoute();
 
@@ -52,44 +68,75 @@
   const follow_count = ref(0);
   const posts = ref({});
 
+  const canFollow = ref(false);
+
+  onMounted(() => {
+    // get profile here
+    createHTTP(`authors/${profileId}/`)
+    .get()
+    .then((response) => {
+      console.log(response.data, 51515);
+      profileData.value = response.data;
+      console.log(response.data, 567);
+    });
+
+    // see if we can follow this user
+    createHTTP(`authors/${encodeURIComponent(profileId)}/followers/${Cookies.get(USER_AUTHOR_ID_COOKIE)}`).get()
+    .then(response => {
+      canFollow.value = false;
+    }).catch( (e) => {
+      console.log(e,13123123123);
+      canFollow.value = true;
+    })
+
+    createHTTP(`authors/${profileId}/followers/`)
+    .get()
+    .then((response) => {
+      console.log(response,123123123);
+      let data = response.data
+      console.log(data, 51515);
+      followers.value = data.items;
+      follow_count.value = data.items.length;
+      console.log(response.data, 567);
+    });
+
+    createHTTP(`authors/${profileId}/posts/`)
+    .get()
+    .then((response) => {
+      let data = response.data
+      console.log(data, 5124124);
+      posts.value = data.items;
+      console.log(response.data, 567);
+    });
+
+  });
+
   let profileId = route.params.id;
 
   if (!profileId){
     profileId = Cookies.get(USER_AUTHOR_ID_COOKIE);
   }
 
-  createHTTP(`authors/${profileId}/`)
-  .get()
-  .then((response) => {
-    console.log(response.data, 51515);
-    profileData.value = response.data;
-    console.log(response.data, 567);
-  });
 
-  createHTTP(`authors/${profileId}/followers/`)
-  .get()
-  .then((response) => {
-    console.log(response,123123123);
-    let data = response.data
-    console.log(data, 51515);
-    followers.value = data.items;
-    follow_count.value = data.items.length;
-    console.log(response.data, 567);
-  });
 
-  createHTTP(`authors/${profileId}/posts/`)
-  .get()
-  .then((response) => {
-    let data = response.data
-    console.log(data, 5124124);
-    posts.value = data.items;
-    console.log(response.data, 567);
-  });
+  const statusMessage = ref("");
+
+  const showStatus = computed(() => statusMessage.value.length > 0);
 
 
   function follow(){
 
-    createHTTP(`authors/${profileId}/followers`)
+    createHTTP(`authors/${encodeURIComponent(profileId)}/followers/${Cookies.get(USER_AUTHOR_ID_COOKIE)}`).post('')
+    .then(response => {
+      canFollow.value = false;
+      statusMessage.value = "Follow request sent to user!";
+
+    }).catch( (e) => {
+      console.log(e,13123123123);
+      canFollow.value = true;
+      statusMessage.value = "Failed to follow user!";
+    })
+
   }
 
   

--- a/InstaTonne-FrontEnd/src/components/stream_cards/CommentCard.vue
+++ b/InstaTonne-FrontEnd/src/components/stream_cards/CommentCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="mx-auto" color="#fff" theme="light" max-width="400">
+  <v-card class="mx-auto" color="#fff" theme="light" max-width="100%">
     <v-card-actions>
       <v-list-item class="w-100">
         <v-list-item-title>{{ author.displayName }}</v-list-item-title>

--- a/InstaTonne-FrontEnd/src/components/stream_cards/PostFullCard.vue
+++ b/InstaTonne-FrontEnd/src/components/stream_cards/PostFullCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="mx-auto" color="#eee" theme="light" max-width="400">
+  <v-card class="mx-auto" color="#eee" theme="light" max-width="80%">
     <v-card-actions>
       <v-list-item class="w-100">
         <!-- <template v-slot:prepend>
@@ -34,12 +34,12 @@
 
 
 
-    <v-card class="mx-4">
+    <v-card class="mx-4" min-height="30vh">
       <v-list-item-title><h3>{{
         props.postData.title
       }}</h3></v-list-item-title>
       <v-img v-if="isImage" :src="require('${ props.postData.content }')" />
-      <v-card-text v-else>
+      <v-card-text class="my-10" v-else>
         <span>{{ props.postData.content }}</span>
       </v-card-text>
     </v-card>

--- a/InstaTonneApis/endpoints/comments.py
+++ b/InstaTonneApis/endpoints/comments.py
@@ -143,7 +143,7 @@ def single_post_comments_post(request: HttpRequest, author_id: str, post_id: str
 
         if post is None:
             return HttpResponse(status=404)
-        
+        print("SENDING COMMENT ON POST ",post.id_url)
         body: dict = json.loads(request.body)
         comment: dict = {
             "type" : "comment",

--- a/InstaTonneApis/endpoints/followers.py
+++ b/InstaTonneApis/endpoints/followers.py
@@ -1,8 +1,8 @@
 from django.http import HttpRequest, HttpResponse
 import json
-from ..models import Follow, FollowSerializer, Author
-from .utils import valid_requesting_user, get_all_urls, get_one_url
-from urllib.parse import unquote
+from ..models import Follow, FollowSerializer, Author, AuthorSerializer
+from .utils import valid_requesting_user, get_all_urls, get_one_url, get_author, send_to_single_inbox
+from urllib.parse import unquote, quote
 import re
 
 
@@ -30,15 +30,66 @@ def single_author_follower(request: HttpRequest):
     else:
         return HttpResponse(status=405)
 
+    #delete follower / follow request
     if request.method == "DELETE":
         return delete_author_follower(request, author_id, foreign_author_id)
+    #accept follow request
     elif request.method == "PUT":
         return put_author_follower(request, author_id, foreign_author_id)
+    #this endpoint is for checking if a local author is following a remote author.
+    elif request.method == "GET" and "/" in author_id:
+        print("GETTING REMOTE AUTHOR")
+        return check_author_follower_remote(request,author_id,foreign_author_id)
+    #return if foreign_author_id is a follower of author_id
     elif request.method == "GET":
         return check_author_follower(request, author_id, foreign_author_id)
+    #if method is post, then foreign_author_id must be a url. we then make a follow request from author_id to foreign_author_id
+    #author_id should be a local id, as this api endpoint is only for our local web interface
+    elif request.method == "POST" and "/" in author_id:
+        print("sending follow to inbox")
+        return post_author_follower(request,author_id,foreign_author_id)
     return HttpResponse(status=405)
 
+def post_author_follower(request: HttpRequest, author_id : str, foreign_author_id : str):
 
+    if not valid_requesting_user(request, foreign_author_id):
+        print("invalid requesting user! post_author_follower")
+        return HttpResponse(status=403)
+    
+    author = get_author(foreign_author_id)
+
+    status, foreign_author = get_one_url(author_id)
+
+    if status != 200:
+        return HttpResponse(status=status)
+    try:
+        foreign_author_json = json.loads(foreign_author)
+        summary = author.displayName + " wants to follow " + foreign_author_json["displayName"]
+    except Exception as e:
+        print("INCORRECT FOLLOW REQUEST FORMAT RECEIVED!")
+        print(foreign_author)
+        return HttpResponse(status=400,content="Incorrect follow request format received from foreign author url")
+    
+
+    #make follow request object
+    request : dict = {
+        "type" : "follow",
+        "actor" : AuthorSerializer(author).data,
+        "object" : foreign_author_json,
+        "summary" : summary
+    }
+
+
+    print("SENDING FOLLOW REQUEST TO INBOX!")
+
+
+    status = send_to_single_inbox(author_id,request)
+
+    if status != 200:
+        print("SENDING TO INBOX FAILED!")
+        return HttpResponse(status=status)
+    
+    return HttpResponse(status=200)
 # get the followers of an author
 def single_author_followers_get(request: HttpRequest, author_id: str):
     follows = Follow.objects.all().filter(object=author_id)
@@ -110,6 +161,71 @@ def put_author_follower(request: HttpRequest, author_id: str, foreign_author_id:
 # return success if foreign_author follows author
 def check_author_follower(request: HttpRequest, author_id: str, foreign_author_id: str):
     user: Author | None = Author.objects.all().filter(pk=author_id).first()
+    
+    if user is None:
+        return HttpResponse(status=404)
+    
+    print("FOREIGN AUTHOR: ",foreign_author_id)
+
+    #if foreign author is local author:
+    if user.id_url == foreign_author_id:
+        return HttpResponse(status=200)
+    
+    follows = Follow.objects.all().filter(object=user, follower_url=foreign_author_id)
+
+    if len(follows) == 0:
+        return HttpResponse(status=404)
+    
+    follow = follows[0]
+
+    if not follow.accepted:
+        return HttpResponse(status=404)
+
+    return HttpResponse(status=200)
+
+#check if a local author is following a remote author. foreign_author_id in this case should be a local authro
+def check_author_follower_remote(request : HttpRequest, author_id : str, foreign_author_id : str):
+
+    if not valid_requesting_user(request, foreign_author_id):
+        print("invalid requesting user!")
+        return HttpResponse(status=403)
+    
+    author = get_author(foreign_author_id)
+
+
+
+    if not author:
+        print("local author does not exist :(")
+        return HttpResponse(status=404,content="Local author does not exist")
+    
+
+    follower_url = author_id + "/followers/" + quote(author.id_url)
+
+    print("CHECKING IF ",foreign_author_id, " CAN FOLLOW ",author_id)
+
+    status,_ = get_one_url(follower_url)
+
+    print("GOT CODE: ",status)
+
+    return HttpResponse(status=status)
+
+#get the actual request object. this is for our local front end ONLY (for the inbox to retrieve follow requests)
+def get_request_object(request: HttpRequest):
+
+    print("GETTING REQUEST OBJECT")
+    if request.method != "GET":
+        return HttpResponse(status=405)
+
+    matched = re.search(r"^\/authors\/(.*?)\/followers\/(.*?)\/request\/?$", request.path)
+    print(request.path)
+    if matched:
+        author_id: str = matched.group(1)
+        foreign_author_id: str = matched.group(2)
+    else:
+        print("id broken")
+        return HttpResponse(status=405)
+    
+    user: Author | None = get_author(author_id)
     
     if user is None:
         return HttpResponse(status=404)

--- a/InstaTonneApis/endpoints/followers.py
+++ b/InstaTonneApis/endpoints/followers.py
@@ -167,7 +167,7 @@ def check_author_follower(request: HttpRequest, author_id: str, foreign_author_i
     
     print("FOREIGN AUTHOR: ",foreign_author_id)
 
-    #if foreign author is local author:
+    #if foreign author is local author return 404
     if user.id_url == foreign_author_id:
         return HttpResponse(status=200)
     

--- a/InstaTonneApis/endpoints/inbox.py
+++ b/InstaTonneApis/endpoints/inbox.py
@@ -57,6 +57,7 @@ def get_inbox(request : HttpRequest, id : str):
 def parse_inbox_post(data : dict, user : Author):
 
     if "type" not in data:
+        print("NO TYPE ON INBOX POST!")
         return None
     
     data_type = str(data["type"].lower())
@@ -82,7 +83,8 @@ def parse_inbox_comment(data,user):
     # }
 
     #get post from post_id (get last non empty field after splitting on /)
-
+    
+    print("POST LINK",data["post"])
     post_local_id = [x for x in data["post"].split("/") if x][-1]
 
     #now get the post
@@ -90,6 +92,7 @@ def parse_inbox_comment(data,user):
     post = Post.objects.filter(id=post_local_id).first()
 
     if not post:
+        print("POST WITH ID ",post_local_id, " DOES NOT EXIST")
         return None
     
     obj = Comment.objects.create(type=data["type"],id_url="",contentType=data["contentType"],comment=data["content"],author=data["author"],post=post)
@@ -105,6 +108,7 @@ def parse_inbox_like(data,user):
    
     local_id = [x for x in data["object"].split("/") if x][-1]
 
+    print(local_id)
 
     #now get the post
 

--- a/InstaTonneApis/endpoints/inbox.py
+++ b/InstaTonneApis/endpoints/inbox.py
@@ -183,7 +183,7 @@ def parse_inbox_follow_request(data : dict, user: Author):
 
         obj.save()
 
-        return HOSTNAME + "/authors/" + user.id + "/followers/" + quote(actor_id)
+        return HOSTNAME + "/authors/" + user.id + "/followers/" + quote(actor_id) + "/request"
 """
 Post an item to a users inbox!
 """

--- a/InstaTonneApis/endpoints/utils.py
+++ b/InstaTonneApis/endpoints/utils.py
@@ -58,9 +58,10 @@ def send_to_single_inbox(author_url : str, data : dict):
     try:
         response: requests.Response = requests.post(inbox_url,json.dumps(data)) # this will probs have to get changed when the inbox endpoints get updated
     except Exception as e:
-        print("SERVER DOWN!")
-        return True
-    return response.status_code == 200
+        print(e)
+        print("SERVER DOWN! Returning 404")
+        return 404
+    return response.status_code
 
 def send_to_inboxes(author_id: str, author_url: str, data : dict, item_visibility: str):
     follows = Follow.objects.all().filter(object=author_id, accepted=True)

--- a/InstaTonneApis/fixtures/initial_data.json
+++ b/InstaTonneApis/fixtures/initial_data.json
@@ -19,6 +19,14 @@
     }
   },
   {
+    "model": "auth.User",
+    "pk": 3,
+    "fields": {
+      "username": "username2",
+      "password": "pbkdf2_sha256$390000$qNmGFiZJzIeaxwOP6Ydwv8$9jc3/9tEt3I2meX52eYmf2LezRPVNIBnfKZPHW6qhtk="
+    }
+  },
+  {
     "model": "InstaTonneApis.Author",
     "fields": {
       "id" : "1",

--- a/InstaTonneApis/urls.py
+++ b/InstaTonneApis/urls.py
@@ -18,7 +18,7 @@ from django.urls import path, include, re_path
 from rest_framework import routers, serializers, viewsets
 from rest_framework.schemas import get_schema_view
 from .endpoints.authors import single_author, authors, get_author_id
-from .endpoints.followers import single_author_followers, single_author_follower
+from .endpoints.followers import single_author_followers, single_author_follower, get_request_object
 from .endpoints.register import register_author
 from .endpoints.login import login
 from .endpoints.posts import single_author_posts, single_author_post, single_author_post_image
@@ -46,6 +46,7 @@ urlpatterns = [
     re_path(r"^authors\/.+?\/posts\/.+?\/?$", single_author_post),
     re_path(r"^authors\/.+?\/posts\/?$", single_author_posts),
     re_path(r"^authors\/.+?\/inbox\/?$",inbox_endpoint),
+    re_path(r"^authors\/.+?\/followers\/.+?/request\/?$", get_request_object),
     re_path(r"^authors\/.+?\/followers\/.+?\/?$", single_author_follower),
     re_path(r"^authors\/.+?\/followers\/?$", single_author_followers),
     re_path(r"^authors\/.+?\/?$", single_author),

--- a/InstaTonneApis/urls.py
+++ b/InstaTonneApis/urls.py
@@ -46,7 +46,7 @@ urlpatterns = [
     re_path(r"^authors\/.+?\/posts\/.+?\/?$", single_author_post),
     re_path(r"^authors\/.+?\/posts\/?$", single_author_posts),
     re_path(r"^authors\/.+?\/inbox\/?$",inbox_endpoint),
-    re_path(r"^authors\/.+?\/followers\/.+?/request\/?$", get_request_object),
+    re_path(r"^authors\/.+?\/followers\/.+?\/request\/?$", get_request_object),
     re_path(r"^authors\/.+?\/followers\/.+?\/?$", single_author_follower),
     re_path(r"^authors\/.+?\/followers\/?$", single_author_followers),
     re_path(r"^authors\/.+?\/?$", single_author),

--- a/documentation/InstaTonne.postman_collection.json
+++ b/documentation/InstaTonne.postman_collection.json
@@ -152,7 +152,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"type\": \"Follow\",      \r\n    \"summary\":\"User 2 wants to follow User1\",\r\n    \"actor\":{\r\n        \"type\":\"author\",\r\n        \"id\":\"http://127.0.0.1:8000/authors/2\",\r\n        \"url\":\"url1\",\r\n        \"host\":\"host1\",\r\n        \"displayName\":\"displayName1\",\r\n        \"github\": \"github1\",\r\n        \"profileImage\": \"https://i.imgur.com/k7XVwpB.jpeg\"\r\n    },\r\n    \"object\":{\r\n        \"type\":\"author\",\r\n        \"id\":\"http://127.0.0.1:8000/authors/1\",\r\n        \"host\":\"host2\",\r\n        \"displayName\":\"displayName2\",\r\n        \"url\":\"url2\",\r\n        \"github\": \"github2\",\r\n        \"profileImage\": \"https://i.imgur.com/k7XVwpB.jpeg\"\r\n    }\r\n}",
+					"raw": "{\r\n    \"type\": \"Follow\",      \r\n    \"summary\":\"User 2 wants to follow User1\",\r\n    \"actor\":{\r\n        \"type\":\"author\",\r\n        \"id\":\"http://127.0.0.1:8000/authors/9839dde5e9db4deeba850b12d7a919ea\",\r\n        \"url\":\"url1\",\r\n        \"host\":\"host1\",\r\n        \"displayName\":\"displayName1\",\r\n        \"github\": \"github1\",\r\n        \"profileImage\": \"https://i.imgur.com/k7XVwpB.jpeg\"\r\n    },\r\n    \"object\":{\r\n        \"type\":\"author\",\r\n        \"id\":\"http://127.0.0.1:8000/authors/7705e94f12a043e38c8f32c7745d96a3\",\r\n        \"host\":\"host2\",\r\n        \"displayName\":\"displayName2\",\r\n        \"url\":\"url2\",\r\n        \"github\": \"github2\",\r\n        \"profileImage\": \"https://i.imgur.com/k7XVwpB.jpeg\"\r\n    }\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -160,7 +160,7 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:8000/authors/1/inbox/",
+					"raw": "http://localhost:8000/authors/7705e94f12a043e38c8f32c7745d96a3/inbox/",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -168,7 +168,7 @@
 					"port": "8000",
 					"path": [
 						"authors",
-						"1",
+						"7705e94f12a043e38c8f32c7745d96a3",
 						"inbox",
 						""
 					]
@@ -863,6 +863,30 @@
 			"response": []
 		},
 		{
+			"name": "post comment",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/1/comments/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"1",
+						"comments",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "post comments",
 			"request": {
 				"method": "POST",
@@ -875,7 +899,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"contentType\" : \"contentType76.1\",\n    \"comment\" : \"comment76.1\",\n    \"author\" : 1\n}",
+					"raw": "{\n    \"type\" : \"comment\",\n    \"contentType\" : \"contentType76.1\",\n    \"comment\" : \"comment76.1\",\n    \"author\" : \"http://localhost:8000/authors/1\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -896,6 +920,191 @@
 						"1",
 						"comments",
 						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post comments remote",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-CSRFToken",
+						"value": "{{csrftoken}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"type\" : \"comment\",\n    \"contentType\" : \"contentType76.1\",\n    \"comment\" : \"comment76.1\",\n    \"author\" : \"http://localhost:8000/authors/1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1/comments/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1",
+						"comments",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post likes",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/1/likes",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"1",
+						"likes"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post likes remote",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1/likes",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1",
+						"likes"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post like",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/1/likes/1",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"1",
+						"likes",
+						"1"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post likes",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-CSRFToken",
+						"value": "{{csrftoken}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"contentType\" : \"contentType76.1\",\n    \"comment\" : \"comment76.1\",\n    \"author\" : \"http://localhost:8000/authors/1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/1/likes",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"1",
+						"likes"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post likes remote",
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "X-CSRFToken",
+						"value": "{{csrftoken}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"contentType\" : \"contentType76.1\",\n    \"comment\" : \"comment76.1\",\n    \"author\" : \"http://localhost:8000/authors/1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8000/authors/1/posts/http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1/likes",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8000",
+					"path": [
+						"authors",
+						"1",
+						"posts",
+						"http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1",
+						"likes"
 					]
 				}
 			},
@@ -952,12 +1161,12 @@
 			"response": []
 		},
 		{
-			"name": "post likes",
+			"name": "comment like",
 			"request": {
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8000/authors/1/posts/1/likes",
+					"raw": "http://localhost:8000/authors/1/posts/1/comments/1/likes/2",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -968,19 +1177,30 @@
 						"1",
 						"posts",
 						"1",
-						"likes"
+						"comments",
+						"1",
+						"likes",
+						"2"
 					]
 				}
 			},
 			"response": []
 		},
 		{
-			"name": "post likes remote",
+			"name": "comment likes",
 			"request": {
-				"method": "GET",
+				"method": "POST",
+				"header": []
+			},
+			"response": []
+		},
+		{
+			"name": "comment likes remote",
+			"request": {
+				"method": "POST",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:8000/authors/1/posts/http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1/likes",
+					"raw": "http://localhost:8000/authors/1/posts/1/comments/http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1%2Fcomments%2F1/likes",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -990,7 +1210,9 @@
 						"authors",
 						"1",
 						"posts",
-						"http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1",
+						"1",
+						"comments",
+						"http%3A%2F%2Flocalhost%3A8001%2Fauthors%2F1%2Fposts%2F1%2Fcomments%2F1",
 						"likes"
 					]
 				}

--- a/documentation/openapi.yml
+++ b/documentation/openapi.yml
@@ -4,6 +4,7 @@ info:
   version: 1.0.0
 servers:
   - url: http://localhost:8000
+  - url: http://localhost:8001
 paths:
   /authors/1/inbox/:
     get:
@@ -18,35 +19,28 @@ paths:
     post:
       tags:
         - default
-      summary: post follow request
+      summary: post comment inbox
       requestBody:
         content:
           application/json:
             schema:
               type: object
               example:
-                type: Follow
-                summary: Greg wants to follow Lara
-                actor:
+                type: comment
+                author:
                   type: author
                   id: >-
                     http://127.0.0.1:5454/authors/1d698d25ff008f7538453c120f581471
                   url: >-
                     http://127.0.0.1:5454/authors/1d698d25ff008f7538453c120f581471
                   host: http://127.0.0.1:5454/
-                  displayName: Greg Johnson
                   github: http://github.com/gjohnson
                   profileImage: https://i.imgur.com/k7XVwpB.jpeg
-                object:
-                  type: author
-                  id: >-
-                    http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e
-                  host: http://127.0.0.1:5454/
-                  displayName: Lara Croft
-                  url: >-
-                    http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e
-                  github: http://github.com/laracroft
-                  profileImage: https://i.imgur.com/k7XVwpB.jpeg
+                comment: Sick Olde English
+                contentType: text/markdown
+                published: '2015-03-09T13:07:04+00:00'
+                id: >-
+                  http://127.0.0.1:5454/authors/9de17f29c12e8f97bcbbd34cc908f1baba40658e/posts/de305d54-75b4-431b-adb2-eb6b9e546013/comments/f6255bb01c648fe967714d52a89e8e9c
       parameters:
         - name: X-CSRFToken
           in: header
@@ -62,6 +56,48 @@ paths:
       tags:
         - default
       summary: http://localhost:8000/service/authors/1/inbox/
+      parameters:
+        - name: X-CSRFToken
+          in: header
+          schema:
+            type: string
+          example: f3gPbKMLdKXINBC9X3UZGz8fcnzFF8ml
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/7705e94f12a043e38c8f32c7745d96a3/inbox/:
+    post:
+      tags:
+        - default
+      summary: post follow request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                type: Follow
+                summary: User 2 wants to follow User1
+                actor:
+                  type: author
+                  id: >-
+                    http://127.0.0.1:8000/authors/9839dde5e9db4deeba850b12d7a919ea
+                  url: url1
+                  host: host1
+                  displayName: displayName1
+                  github: github1
+                  profileImage: https://i.imgur.com/k7XVwpB.jpeg
+                object:
+                  type: author
+                  id: >-
+                    http://127.0.0.1:8000/authors/7705e94f12a043e38c8f32c7745d96a3
+                  host: host2
+                  displayName: displayName2
+                  url: url2
+                  github: github2
+                  profileImage: https://i.imgur.com/k7XVwpB.jpeg
       parameters:
         - name: X-CSRFToken
           in: header
@@ -115,7 +151,7 @@ paths:
     get:
       tags:
         - default
-      summary: authors
+      summary: authors remote
       parameters:
         - name: page
           in: query
@@ -142,6 +178,16 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /authors/http://localhost:8001/authors/1:
+    get:
+      tags:
+        - default
+      summary: author remote
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
   /authors/1/:
     post:
       tags:
@@ -153,9 +199,9 @@ paths:
             schema:
               type: object
               example:
-                displayName: displayName1
-                github: github1
-                profileImage: profileImage1
+                displayName: displayName2
+                github: github76.1
+                profileImage: profileImage2
       parameters:
         - name: X-CSRFToken
           in: header
@@ -177,7 +223,17 @@ paths:
           description: Successful response
           content:
             application/json: {}
-  /authors/1/followers/2/:
+  /authors/http://localhost:8001/authors/1/followers:
+    get:
+      tags:
+        - default
+      summary: author followers remote
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/followers/http://localhost:8000/authors/2:
     get:
       tags:
         - default
@@ -187,7 +243,6 @@ paths:
           description: Successful response
           content:
             application/json: {}
-  /authors/2/followers/1/:
     put:
       tags:
         - default
@@ -241,6 +296,27 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /authors/http://localhost:8001/authors/1/posts:
+    get:
+      tags:
+        - default
+      summary: author posts remote
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+          example: '1'
+        - name: size
+          in: query
+          schema:
+            type: integer
+          example: '5'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
   /authors/1/posts/:
     post:
       tags:
@@ -258,7 +334,7 @@ paths:
                 description: description76.1
                 contentType: contentType76.1
                 content: content76.1
-                visibility: visibility76.1
+                visibility: PUBLIC
                 categories:
                   - cat76.0
                   - cat76.1
@@ -285,6 +361,16 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /authors/1/posts/http://localhost:8001/authors/1/posts/1:
+    get:
+      tags:
+        - default
+      summary: author post remote
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
   /authors/1/posts/1/:
     post:
       tags:
@@ -300,7 +386,7 @@ paths:
                 description: description76.1
                 contentType: contentType76.1
                 content: content76.1
-                visibility: visibility76.1
+                visibility: PUBLIC
                 categories:
                   - cat76.0
                   - cat76.1
@@ -347,8 +433,8 @@ paths:
                 origin: origin76.1
                 description: description76.1
                 contentType: image/png;base64
-                content: >- base64encodedimage
-                visibility: visibility
+                content: base64stuff
+                visibility: visibility76.1
                 categories:
                   - cat76.0
                   - cat76.1
@@ -386,6 +472,37 @@ paths:
           description: Successful response
           content:
             application/json: {}
+  /authors/1/posts/http://localhost:8001/authors/1/posts/1/comments:
+    get:
+      tags:
+        - default
+      summary: post comments remote
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+          example: '1'
+        - name: size
+          in: query
+          schema:
+            type: integer
+          example: '5'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/posts/1/comments/1:
+    get:
+      tags:
+        - default
+      summary: post comment
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
   /authors/1/posts/1/comments/:
     post:
       tags:
@@ -397,9 +514,10 @@ paths:
             schema:
               type: object
               example:
+                type: comment
                 contentType: contentType76.1
                 comment: comment76.1
-                author: 1
+                author: http://localhost:8000/authors/1
       parameters:
         - name: X-CSRFToken
           in: header
@@ -411,11 +529,27 @@ paths:
           description: Successful response
           content:
             application/json: {}
-  /authors/1/posts/1/comments/1/likes:
-    get:
+  /authors/1/posts/http://localhost:8001/authors/1/posts/1/comments/:
+    post:
       tags:
         - default
-      summary: comment likes
+      summary: post comments remote
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                type: comment
+                contentType: contentType76.1
+                comment: comment76.1
+                author: http://localhost:8000/authors/1
+      parameters:
+        - name: X-CSRFToken
+          in: header
+          schema:
+            type: string
+          example: '{{csrftoken}}'
       responses:
         '200':
           description: Successful response
@@ -431,11 +565,130 @@ paths:
           description: Successful response
           content:
             application/json: {}
+    post:
+      tags:
+        - default
+      summary: post likes
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                contentType: contentType76.1
+                comment: comment76.1
+                author: http://localhost:8000/authors/1
+      parameters:
+        - name: X-CSRFToken
+          in: header
+          schema:
+            type: string
+          example: '{{csrftoken}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/posts/http://localhost:8001/authors/1/posts/1/likes:
+    get:
+      tags:
+        - default
+      summary: post likes remote
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - default
+      summary: post likes remote
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              example:
+                contentType: contentType76.1
+                comment: comment76.1
+                author: http://localhost:8000/authors/1
+      parameters:
+        - name: X-CSRFToken
+          in: header
+          schema:
+            type: string
+          example: '{{csrftoken}}'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/posts/1/likes/1:
+    get:
+      tags:
+        - default
+      summary: post like
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/posts/1/comments/1/likes:
+    get:
+      tags:
+        - default
+      summary: comment likes
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/posts/1/comments/http://localhost:8001/authors/1/posts/1/comments/1/likes:
+    get:
+      tags:
+        - default
+      summary: comment likes remote
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+    post:
+      tags:
+        - default
+      summary: comment likes remote
+      requestBody:
+        content: {}
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/1/posts/1/comments/1/likes/2:
+    get:
+      tags:
+        - default
+      summary: comment like
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
   /authors/1/liked:
     get:
       tags:
         - default
       summary: author likes
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json: {}
+  /authors/http://localhost:8001/authors/1/liked:
+    get:
+      tags:
+        - default
+      summary: author likes remote
       responses:
         '200':
           description: Successful response


### PR DESCRIPTION
New followers endpoints:

GET /authors/id/followers/foreign id/request : returns request object with accepted status. for local inbox only!

GET /authors/id/followers/foreign id url: returns 200 if foreign id url is following local author id. otherwise, returns 404. Also returns 404 if foreign id url is the url of the local author.

POST /authors/ url to an author (foreign or local) / followers / local author id : sends a follow request from the user you are logged in as (local author id), to another author

On the front end:

Profiles now have a follow button. This UI should work even when we integrate with remote servers cause its all proxied through our backend same as everything else. Button should be disabled if you cannot follow them (its your own profile or you're already following them). 

Issue: no endpoint for seeing if a follow request exists (not specified in api docs), so technically a user can spam follow requests to another users inbox. oh well